### PR TITLE
natgeo: fix rounding errors

### DIFF
--- a/AnimationControllers/CENatGeoAnimationController.m
+++ b/AnimationControllers/CENatGeoAnimationController.m
@@ -53,6 +53,9 @@ static const CGFloat kAnimationFirstPartRatio = 0.8f;
             }];
             
         } completion:^(BOOL finished) {
+            fromViewController.view.layer.transform = CATransform3DIdentity;
+            toViewController.view.layer.transform = CATransform3DIdentity;
+            transitionContext.containerView.layer.transform = CATransform3DIdentity;
             [transitionContext completeTransition:![transitionContext transitionWasCancelled]];
         }];
         
@@ -88,8 +91,11 @@ static const CGFloat kAnimationFirstPartRatio = 0.8f;
                                           animations:^{
                 sourceLastTransform(fromLayer);
             }];
-            
+
         } completion:^(BOOL finished) {
+            fromViewController.view.layer.transform = CATransform3DIdentity;
+            toViewController.view.layer.transform = CATransform3DIdentity;
+            transitionContext.containerView.layer.transform = CATransform3DIdentity;
             [transitionContext completeTransition:![transitionContext transitionWasCancelled]];
         }];
     }


### PR DESCRIPTION
In the demo app, if you select 'natgeo' for modal transitions, and then open/close settings a few times, you'll start to see Crazy Layout issues. This is due to rounding errors from the layer transforms not reversing perfectly, so reseting the transform matrices after the anim fixes it.
