### PR TITLE
Fix to CEHorizontalSwipeInteractionController when pan gesture's translation.x == 0

### DIFF
--- a/InteractionControllers/CEHorizontalSwipeInteractionController.m
+++ b/InteractionControllers/CEHorizontalSwipeInteractionController.m
@@ -42,6 +42,8 @@
     switch (gestureRecognizer.state) {
         case UIGestureRecognizerStateBegan: {
             
+            if (translation.x == 0) break;//if no horizontal translation returned, simply break and do nothing
+            
             BOOL rightToLeftSwipe = translation.x < 0;
             
             // perform the required navigation operation ...


### PR DESCRIPTION
Sometimes `handleGesture:` incorrectly sets the `BOOL rightToLeftSwipe` to
FALSE when it should be TRUE. When this happens, actions that are associated with a left-to-right pan will get triggered when the user actually performed a right-to-left pan…This is due to `[gestureRecognizer translationInView:gestureRecognizer.view.superview]`  in `handleGesture:` sporadically returning {0, 0}, which seems to occur most often for me when making slow, methodical movement swipes while starting at or near the center of view the gestures are attached to.  Easy solution is to break anytime {0, 0} is returned (where translation.x == 0) so that nothing happens and the `rightToLeftSwipe` BOOL is only set if translation.x <> 0.
