### PR TITLE
Use velocity to get direction for a pan gesture.

### DIFF
--- a/InteractionControllers/CEHorizontalSwipeInteractionController.m
+++ b/InteractionControllers/CEHorizontalSwipeInteractionController.m
@@ -38,17 +38,12 @@
 
 - (void)handleGesture:(UIPanGestureRecognizer*)gestureRecognizer {
     CGPoint translation = [gestureRecognizer translationInView:gestureRecognizer.view.superview];
+    CGPoint vel = [gestureRecognizer velocityInView:gestureRecognizer.view];
     
     switch (gestureRecognizer.state) {
         case UIGestureRecognizerStateBegan: {
             
-            // if the user performs a *very* slow swipe, the initiatlly returned x translation may be zero. This means
-            // that we cannot effectively determine which direction the swipe is, so we just
-            // ignore this interaction.
-            if (translation.x == 0)
-                break;
-            
-            BOOL rightToLeftSwipe = translation.x < 0;
+            BOOL rightToLeftSwipe = vel.x < 0;
             
             // perform the required navigation operation ...
             


### PR DESCRIPTION
Relying on translation to be > 0 can cause a delay in catching the interaction.
Also related to Issue 9.
