### PR TITLE
split wiring pop-interaction controller & animator

### DIFF
--- a/TransitionsDemo/TransitionsDemo/NavigationController.m
+++ b/TransitionsDemo/TransitionsDemo/NavigationController.m
@@ -24,12 +24,23 @@
     return self;
 }
 
-- (id<UIViewControllerAnimatedTransitioning>)navigationController:(UINavigationController *)navigationController animationControllerForOperation:(UINavigationControllerOperation)operation fromViewController:(UIViewController *)fromVC toViewController:(UIViewController *)toVC {
+- (void)navigationController:(UINavigationController *)navigationController willShowViewController:(UIViewController *)viewController animated:(BOOL)animated {
     
+    [self wirePopInteractionControllerTo:viewController];
+}
+
+- (void)wirePopInteractionControllerTo:(UIViewController *)viewController
+{
     // when a push occurs, wire the interaction controller to the to- view controller
-    if (AppDelegateAccessor.navigationControllerInteractionController) {
-        [AppDelegateAccessor.navigationControllerInteractionController wireToViewController:toVC forOperation:CEInteractionOperationPop];
+    if (!AppDelegateAccessor.navigationControllerInteractionController) {
+        return;
     }
+    
+    [AppDelegateAccessor.navigationControllerInteractionController wireToViewController:viewController forOperation:CEInteractionOperationPop];
+}
+
+
+- (id<UIViewControllerAnimatedTransitioning>)navigationController:(UINavigationController *)navigationController animationControllerForOperation:(UINavigationControllerOperation)operation fromViewController:(UIViewController *)fromVC toViewController:(UIViewController *)toVC {
     
     if (AppDelegateAccessor.navigationControllerAnimationController) {
         AppDelegateAccessor.navigationControllerAnimationController.reverse = operation == UINavigationControllerOperationPop;


### PR DESCRIPTION
At first I found it hard to follow why `-navigationController:animationControllerForOperation:fromViewController:toViewController:` was wiring the interaction controller to `toVC`.  After some fiddling in my own app, I found the real event you meant was when a view controller is pushed on the stack to prepare the pop transition.

I find the change makes the intent clear and the code easier to follow.