### PR TITLE
Fixed the issue for gesture's being added twice

### DIFF
--- a/InteractionControllers/CEHorizontalSwipeInteractionController.m
+++ b/InteractionControllers/CEHorizontalSwipeInteractionController.m
@@ -7,17 +7,16 @@
 //
 
 #import "CEHorizontalSwipeInteractionController.h"
+#import <objc/runtime.h>
+
+const NSString *kCEHorizontalSwipeGestureKey = @"kCEHorizontalSwipeGestureKey";
 
 @implementation CEHorizontalSwipeInteractionController {
     BOOL _shouldCompleteTransition;
     UIViewController *_viewController;
-    UIPanGestureRecognizer *_gesture;
     CEInteractionOperation _operation;
 }
 
--(void)dealloc {
-    [_gesture.view removeGestureRecognizer:_gesture];
-}
 
 - (void)wireToViewController:(UIViewController *)viewController forOperation:(CEInteractionOperation)operation{
     _operation = operation;
@@ -27,8 +26,19 @@
 
 
 - (void)prepareGestureRecognizerInView:(UIView*)view {
-    _gesture = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(handleGesture:)];
-    [view addGestureRecognizer:_gesture];
+    
+    UIPanGestureRecognizer *gesture = objc_getAssociatedObject(view, (__bridge const void *)(kCEHorizontalSwipeGestureKey));
+    
+    if (gesture) {
+        [view removeGestureRecognizer:gesture];
+    }
+    
+    
+    gesture = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(handleGesture:)];
+    [view addGestureRecognizer:gesture];
+    
+    objc_setAssociatedObject(view, (__bridge const void *)(kCEHorizontalSwipeGestureKey), gesture,OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+
 }
 
 - (CGFloat)completionSpeed

--- a/InteractionControllers/CEPinchInteractionController.m
+++ b/InteractionControllers/CEPinchInteractionController.m
@@ -7,17 +7,15 @@
 //
 
 #import "CEPinchInteractionController.h"
+#import <objc/runtime.h>
+
+const NSString *kCEPinchGestureKey = @"kCEPinchGestureKey";
 
 @implementation CEPinchInteractionController{
     BOOL _shouldCompleteTransition;
     UIViewController *_viewController;
-    UIPinchGestureRecognizer *_gesture;
     CEInteractionOperation _operation;
     CGFloat _startScale;
-}
-
--(void)dealloc {
-    [_gesture.view removeGestureRecognizer:_gesture];
 }
 
 - (void)wireToViewController:(UIViewController *)viewController forOperation:(CEInteractionOperation)operation{
@@ -28,8 +26,18 @@
 
 
 - (void)prepareGestureRecognizerInView:(UIView*)view {
-    UIPinchGestureRecognizer *gesture = [[UIPinchGestureRecognizer alloc] initWithTarget:self action:@selector(handleGesture:)];
+    
+    UIPinchGestureRecognizer *gesture = objc_getAssociatedObject(view, (__bridge const void *)(kCEPinchGestureKey));
+    
+    if (gesture) {
+        [view removeGestureRecognizer:gesture];
+    }
+    
+    gesture = [[UIPinchGestureRecognizer alloc] initWithTarget:self action:@selector(handleGesture:)];
     [view addGestureRecognizer:gesture];
+    
+    objc_setAssociatedObject(view, (__bridge const void *)(kCEPinchGestureKey), gesture,OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+
 }
 
 - (CGFloat)completionSpeed

--- a/InteractionControllers/CEVerticalSwipeInteractionController.m
+++ b/InteractionControllers/CEVerticalSwipeInteractionController.m
@@ -7,17 +7,16 @@
 //
 
 #import "CEVerticalSwipeInteractionController.h"
+#import <objc/runtime.h>
+
+const NSString *kCEVerticalSwipeGestureKey = @"kCEVerticalSwipeGestureKey";
 
 @implementation CEVerticalSwipeInteractionController {
     BOOL _shouldCompleteTransition;
     UIViewController *_viewController;
-    UIPanGestureRecognizer *_gesture;
     CEInteractionOperation _operation;
 }
 
--(void)dealloc {
-    [_gesture.view removeGestureRecognizer:_gesture];
-}
 
 - (void)wireToViewController:(UIViewController *)viewController forOperation:(CEInteractionOperation)operation{
     
@@ -33,8 +32,17 @@
 
 
 - (void)prepareGestureRecognizerInView:(UIView*)view {
-    _gesture = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(handleGesture:)];
-    [view addGestureRecognizer:_gesture];
+    UIPanGestureRecognizer *gesture = objc_getAssociatedObject(view, (__bridge const void *)(kCEVerticalSwipeGestureKey));
+    
+    if (gesture) {
+        [view removeGestureRecognizer:gesture];
+    }
+ 
+    gesture = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(handleGesture:)];
+    [view addGestureRecognizer:gesture];
+    
+    objc_setAssociatedObject(view, (__bridge const void *)(kCEVerticalSwipeGestureKey), gesture,OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+
 }
 
 - (CGFloat)completionSpeed

--- a/TabBarDemo/TabBarDemo.xcodeproj/project.xcworkspace/xcshareddata/TabBarDemo.xccheckout
+++ b/TabBarDemo/TabBarDemo.xcodeproj/project.xcworkspace/xcshareddata/TabBarDemo.xccheckout
@@ -10,31 +10,31 @@
 	<string>TabBarDemo</string>
 	<key>IDESourceControlProjectOriginsDictionary</key>
 	<dict>
-		<key>30A09F19-8934-4565-870F-6CCBED565829</key>
-		<string>https://github.com/ColinEberhardt/ViewController-Transitions-Library.git</string>
+		<key>C9B960E113CD2F1E13B17A07CE56CB3BD674F912</key>
+		<string>https://github.com/cyndibaby905/VCTransitionsLibrary.git</string>
 	</dict>
 	<key>IDESourceControlProjectPath</key>
-	<string>TabBarDemo/TabBarDemo.xcodeproj/project.xcworkspace</string>
+	<string>TabBarDemo/TabBarDemo.xcodeproj</string>
 	<key>IDESourceControlProjectRelativeInstallPathDictionary</key>
 	<dict>
-		<key>30A09F19-8934-4565-870F-6CCBED565829</key>
+		<key>C9B960E113CD2F1E13B17A07CE56CB3BD674F912</key>
 		<string>../../..</string>
 	</dict>
 	<key>IDESourceControlProjectURL</key>
-	<string>https://github.com/ColinEberhardt/ViewController-Transitions-Library.git</string>
+	<string>https://github.com/cyndibaby905/VCTransitionsLibrary.git</string>
 	<key>IDESourceControlProjectVersion</key>
-	<integer>110</integer>
+	<integer>111</integer>
 	<key>IDESourceControlProjectWCCIdentifier</key>
-	<string>30A09F19-8934-4565-870F-6CCBED565829</string>
+	<string>C9B960E113CD2F1E13B17A07CE56CB3BD674F912</string>
 	<key>IDESourceControlProjectWCConfigurations</key>
 	<array>
 		<dict>
 			<key>IDESourceControlRepositoryExtensionIdentifierKey</key>
 			<string>public.vcs.git</string>
 			<key>IDESourceControlWCCIdentifierKey</key>
-			<string>30A09F19-8934-4565-870F-6CCBED565829</string>
+			<string>C9B960E113CD2F1E13B17A07CE56CB3BD674F912</string>
 			<key>IDESourceControlWCCName</key>
-			<string>ViewController-Transitions-Library</string>
+			<string>VCTransitionsLibrary</string>
 		</dict>
 	</array>
 </dict>


### PR DESCRIPTION
1.Fixed the issue for gesture's being added twice:
When a push behaviour happens, the toVC add a gesture; when a pop behaviour happens, the toVC should remove the added gesture first, then add a new one. The old code just added gesture twice.
  
2.Removed unnecessary variable and `dealloc ` method:
`UIView` will remove all its gestures when dealloc automatically, so it's no need to remove the added gestures. Furthermore, the `CEBaseInteractionController` is used as a singleton, its `dealloc ` method will never get called.
