### PR TITLE
Fix bugs with iPad split screen transitions on iOS 9

### DIFF
--- a/AnimationControllers/CECrossfadeAnimationController.m
+++ b/AnimationControllers/CECrossfadeAnimationController.m
@@ -14,6 +14,7 @@
     
     // Add the toView to the container
     UIView* containerView = [transitionContext containerView];
+    toView.frame = [transitionContext finalFrameForViewController:toVC];
     [containerView addSubview:toView];
     [containerView sendSubviewToBack:toView];
     

--- a/AnimationControllers/CECubeAnimationController.m
+++ b/AnimationControllers/CECubeAnimationController.m
@@ -24,6 +24,7 @@
 
 - (void)animateTransition:(id<UIViewControllerContextTransitioning>)transitionContext fromVC:(UIViewController *)fromVC toVC:(UIViewController *)toVC fromView:(UIView *)fromView toView:(UIView *)toView
 {
+    toView.frame = [transitionContext finalFrameForViewController:toVC];
 
     //Calculate the direction
     int dir = self.reverse ? 1 : -1;

--- a/AnimationControllers/CEFoldAnimationController.m
+++ b/AnimationControllers/CEFoldAnimationController.m
@@ -23,6 +23,7 @@
     UIView* containerView = [transitionContext containerView];
 
     // move offscreen
+    toView.frame = [transitionContext finalFrameForViewController:toVC];
     toView.frame = CGRectOffset(toView.frame, toView.frame.size.width, 0);
     [containerView addSubview:toView];
     

--- a/AnimationControllers/CEPortalAnimationController.m
+++ b/AnimationControllers/CEPortalAnimationController.m
@@ -93,6 +93,7 @@
     [containerView addSubview:fromView];
     
     // add the to- view and send offscreen (we need to do this in order to allow snapshotting)
+    toView.frame = [transitionContext finalFrameForViewController:toVC];
     toView.frame = CGRectOffset(toView.frame, toView.frame.size.width, 0);
     [containerView addSubview:toView];
     

--- a/TransitionsDemo/TransitionsDemo.xcodeproj/project.pbxproj
+++ b/TransitionsDemo/TransitionsDemo.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		72EE96D817EF47A60097DF82 /* CECardsAnimationController.m in Sources */ = {isa = PBXBuildFile; fileRef = 72EE96D717EF47A60097DF82 /* CECardsAnimationController.m */; };
 		72EE96DB17EF66040097DF82 /* CEVerticalSwipeInteractionController.m in Sources */ = {isa = PBXBuildFile; fileRef = 72EE96DA17EF66040097DF82 /* CEVerticalSwipeInteractionController.m */; };
 		7D0D046C1816DBA700F289A6 /* CENatGeoAnimationController.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D0D046B1816DBA700F289A6 /* CENatGeoAnimationController.m */; };
+		A993F2801B80832400553FBD /* Launch Screen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A993F27E1B80832400553FBD /* Launch Screen.storyboard */; };
 		BC46683B198B2E6700A07DF8 /* CEPanAnimationController.m in Sources */ = {isa = PBXBuildFile; fileRef = BC46683A198B2E6700A07DF8 /* CEPanAnimationController.m */; };
 /* End PBXBuildFile section */
 
@@ -83,6 +84,7 @@
 		72EE96DA17EF66040097DF82 /* CEVerticalSwipeInteractionController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CEVerticalSwipeInteractionController.m; sourceTree = "<group>"; };
 		7D0D046A1816DBA700F289A6 /* CENatGeoAnimationController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CENatGeoAnimationController.h; sourceTree = "<group>"; };
 		7D0D046B1816DBA700F289A6 /* CENatGeoAnimationController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CENatGeoAnimationController.m; sourceTree = "<group>"; };
+		A993F27F1B80832400553FBD /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = "Base.lproj/Launch Screen.storyboard"; sourceTree = "<group>"; };
 		BC466839198B2E6700A07DF8 /* CEPanAnimationController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CEPanAnimationController.h; sourceTree = "<group>"; };
 		BC46683A198B2E6700A07DF8 /* CEPanAnimationController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CEPanAnimationController.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -136,6 +138,7 @@
 			children = (
 				7273232E17DFBD4D0072C7FD /* AppDelegate.h */,
 				7273232F17DFBD4D0072C7FD /* AppDelegate.m */,
+				A993F27E1B80832400553FBD /* Launch Screen.storyboard */,
 				7273233117DFBD4D0072C7FD /* Main_iPhone.storyboard */,
 				7273233717DFBD4D0072C7FD /* ViewController.h */,
 				7273233817DFBD4D0072C7FD /* ViewController.m */,
@@ -260,6 +263,7 @@
 			files = (
 				7273233B17DFBD4D0072C7FD /* Images.xcassets in Resources */,
 				7273233317DFBD4D0072C7FD /* Main_iPhone.storyboard in Resources */,
+				A993F2801B80832400553FBD /* Launch Screen.storyboard in Resources */,
 				7273232A17DFBD4D0072C7FD /* InfoPlist.strings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -311,6 +315,14 @@
 				7273233217DFBD4D0072C7FD /* Base */,
 			);
 			name = Main_iPhone.storyboard;
+			sourceTree = "<group>";
+		};
+		A993F27E1B80832400553FBD /* Launch Screen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				A993F27F1B80832400553FBD /* Base */,
+			);
+			name = "Launch Screen.storyboard";
 			sourceTree = "<group>";
 		};
 /* End PBXVariantGroup section */

--- a/TransitionsDemo/TransitionsDemo/Base.lproj/Launch Screen.storyboard
+++ b/TransitionsDemo/TransitionsDemo/Base.lproj/Launch Screen.storyboard
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="8164.2" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8135.1"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="Llm-lL-Icb"/>
+                        <viewControllerLayoutGuide type="bottom" id="xb3-aO-Qok"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/TransitionsDemo/TransitionsDemo/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/TransitionsDemo/TransitionsDemo/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -7,13 +7,28 @@
     },
     {
       "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
       "size" : "40x40",
       "scale" : "2x"
     },
     {
       "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
       "size" : "60x60",
       "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "3x"
     },
     {
       "idiom" : "ipad",

--- a/TransitionsDemo/TransitionsDemo/TransitionsDemo-Info.plist
+++ b/TransitionsDemo/TransitionsDemo/TransitionsDemo-Info.plist
@@ -24,6 +24,8 @@
 	<string>1.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>Launch Screen</string>
 	<key>UIMainStoryboardFile</key>
 	<string>Main_iPhone</string>
 	<key>UIMainStoryboardFile~ipad</key>


### PR DESCRIPTION
The view to be presented may have incorrect frame due to split screen transitions. These animations are fixed: crossfade, cube, fold, and portal.